### PR TITLE
Deletes and recreates ayai.h2.db each time the program is run. 

### DIFF
--- a/src/main/scala/ayai/persistence/DBCreation.scala
+++ b/src/main/scala/ayai/persistence/DBCreation.scala
@@ -22,17 +22,21 @@ import org.squeryl.adapters.H2Adapter
 
 object DBCreation {
   def ensureDbExists() = {
+
     // If DB Doesn't exist, create it
-    if(!Files.exists(Paths.get("ayai.h2.db"))) {
-      Class.forName("org.h2.Driver");
-      SessionFactory.concreteFactory = Some (() =>
-          Session.create(
-          java.sql.DriverManager.getConnection("jdbc:h2:ayai"),
-          new H2Adapter))
-        transaction {
-          AyaiDB.create
-          AyaiDB.printDdl
-        }
+    if(Files.exists(Paths.get("ayai.h2.db"))){
+      Files.delete(Paths.get("ayai.h2.db"))
+    }
+    
+
+    Class.forName("org.h2.Driver");
+    SessionFactory.concreteFactory = Some (() =>
+        Session.create(
+        java.sql.DriverManager.getConnection("jdbc:h2:ayai"),
+        new H2Adapter))
+      transaction {
+        AyaiDB.create
+        // AyaiDB.printDdl
       }
 
     Class.forName("org.h2.Driver");


### PR DESCRIPTION
If you care enough about the bootup time for it to be worth the hassle of dealing with deleting that file manually and only when necessary see what changed in this commit. Basically that file only has to be deleted when the db structure is changed, which shouldn't be too often. However the front end people would probably not mind have a bit of extra load time on the backend if it means they'll never have the backend throw an exception. To ensure that works right for them this commit deletes the db file every run. 
