### PR TITLE
Supervisors

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,3 +1,23 @@
 server {
     secret = "SECRET"
+    port = 8007
+    ip = "0.0.0.0"
+}
+
+akka.actor.deployment {
+    /interpreterrouter {
+        router = round-robin
+            resizer {
+                lower-bound = 2
+                upper-bound = 5
+            }
+    }
+    /processorrouter {
+        router = round-robin
+            resizer {
+                lower-bound = 3
+                upper-bound = 10
+            }
+    }
+
 }

--- a/src/main/scala/ayai/apps/GameLoop.scala
+++ b/src/main/scala/ayai/apps/GameLoop.scala
@@ -82,8 +82,8 @@ object GameLoop {
 
     val networkSystem = ActorSystem("NetworkSystem")
     val messageQueue = networkSystem.actorOf(Props(new NetworkMessageQueue()))
-    val interpreter = networkSystem.actorOf(Props(new NetworkMessageInterpreter(messageQueue)))
-    val messageProcessor = networkSystem.actorOf(Props(new NetworkMessageProcessor(networkSystem, world, socketMap)))
+    val interpreter = networkSystem.actorOf(Props(new NetworkMessageInterpreterSupervisor(messageQueue)))
+    val messageProcessor = networkSystem.actorOf(Props(new NetworkMessageProcessorSupervisor(world, socketMap)))
     val authorization = networkSystem.actorOf(Props(new AuthorizationProcessor()))
 
     val serializer = networkSystem.actorOf(Props(new GameStateSerializer(world, Constants.LOAD_RADIUS)) , name = (new UID()).toString)

--- a/src/main/scala/ayai/networking/NetworkMessageInterpreterSupervisor.scala
+++ b/src/main/scala/ayai/networking/NetworkMessageInterpreterSupervisor.scala
@@ -8,7 +8,7 @@ package ayai.networking
 /** Akka Imports **/
 import akka.actor.{Actor, ActorRef, Props, OneForOneStrategy}
 import akka.actor.SupervisorStrategy.Escalate
-import akka.routing.RoundRobinRouter
+import akka.routing.FromConfig
 
 /** External Imports **/
 import scala.concurrent.duration._
@@ -20,8 +20,10 @@ class NetworkMessageInterpreterSupervisor(queue: ActorRef) extends Actor {
     case _: Exception => Escalate
   }
 
-  val router = context.system.actorOf(Props(new NetworkMessageInterpreter(queue)).withRouter(
-    RoundRobinRouter(5, supervisorStrategy = escalator)))
+  val router = context.system.actorOf(Props(
+    new NetworkMessageInterpreter(queue)).withRouter(
+      FromConfig.withSupervisorStrategy(escalator)), 
+    name="interpreterrouter")
 
   def receive = {
     case message: InterpretMessage =>

--- a/src/main/scala/ayai/networking/NetworkMessageInterpreterSupervisor.scala
+++ b/src/main/scala/ayai/networking/NetworkMessageInterpreterSupervisor.scala
@@ -1,0 +1,33 @@
+package ayai.networking
+
+/**
+ * ayai.networking.NetworkMessageInterpreterSupervisor
+ * Supervising actor for the NetworkMessageInterpreter
+ */
+
+/** Akka Imports **/
+import akka.actor.{Actor, ActorRef, Props, OneForOneStrategy}
+import akka.actor.SupervisorStrategy.Escalate
+import akka.routing.RoundRobinRouter
+
+/** External Imports **/
+import scala.concurrent.duration._
+
+class NetworkMessageInterpreterSupervisor(queue: ActorRef) extends Actor {
+
+  // Escalate exceptions, try up to 10 times, if one actor fails, try just that one again
+  val escalator = OneForOneStrategy(maxNrOfRetries = 10, withinTimeRange = 5 seconds) {
+    case _: Exception => Escalate
+  }
+
+  val router = context.system.actorOf(Props(new NetworkMessageInterpreter(queue)).withRouter(
+    RoundRobinRouter(5, supervisorStrategy = escalator)))
+
+  def receive = {
+    case message: InterpretMessage =>
+      router forward message 
+    case _ =>
+      println("Error: in interpreter supervisor")
+  }
+
+}

--- a/src/main/scala/ayai/networking/NetworkMessageProcessor.scala
+++ b/src/main/scala/ayai/networking/NetworkMessageProcessor.scala
@@ -12,7 +12,7 @@ import ayai.apps.{Constants, GameLoop}
 import crane.{Entity, World}
 
 /** Akka Imports **/
-import akka.actor.{Actor, ActorSystem, ActorRef, Props}
+import akka.actor.{Actor, Props}
 
 /** Socko Imports **/
 import org.mashupbots.socko.events.WebSocketFrameEvent
@@ -31,8 +31,9 @@ import net.liftweb.json.Serialization.{read, write}
 import org.slf4j.{Logger, LoggerFactory}
 
 
-class NetworkMessageProcessor(actorSystem: ActorSystem, world: World, socketMap: ConcurrentMap[String, String]) extends Actor {
+class NetworkMessageProcessor(world: World, socketMap: ConcurrentMap[String, String]) extends Actor {
   implicit val formats = Serialization.formats(NoTypeHints)
+  val actorSystem = context.system
   val characterTable = actorSystem.actorOf(Props(new CharacterTable()))
   private val log = LoggerFactory.getLogger(getClass)
 

--- a/src/main/scala/ayai/networking/NetworkMessageProcessorSupervisor.scala
+++ b/src/main/scala/ayai/networking/NetworkMessageProcessorSupervisor.scala
@@ -7,8 +7,8 @@ package ayai.networking
 
 /** Akka Imports **/
 import akka.actor.{Actor, ActorRef, Props, OneForOneStrategy}
-import akka.routing.RoundRobinRouter
 import akka.actor.SupervisorStrategy.Escalate
+import akka.routing.FromConfig
 
 /** Crane Imports **/
 import crane.{World}
@@ -24,8 +24,10 @@ class NetworkMessageProcessorSupervisor(world: World, socketMap: ConcurrentMap[S
     case _: Exception => Escalate
   }
 
-  val router = context.system.actorOf(Props(new NetworkMessageProcessor(world, socketMap)).withRouter(
-    RoundRobinRouter(5, supervisorStrategy = escalator)))
+val router = context.system.actorOf(Props(
+  new NetworkMessageProcessor(world,socketMap)).withRouter(
+    FromConfig.withSupervisorStrategy(escalator)), 
+  name = "processorrouter")
 
   def receive = {
     case message: ProcessMessage =>

--- a/src/main/scala/ayai/networking/NetworkMessageProcessorSupervisor.scala
+++ b/src/main/scala/ayai/networking/NetworkMessageProcessorSupervisor.scala
@@ -24,7 +24,7 @@ class NetworkMessageProcessorSupervisor(world: World, socketMap: ConcurrentMap[S
     case _: Exception => Escalate
   }
 
-  val router = context.system.actorOf(Props(new NetworkMessageProcessor(context.system, world, socketMap)).withRouter(
+  val router = context.system.actorOf(Props(new NetworkMessageProcessor(world, socketMap)).withRouter(
     RoundRobinRouter(5, supervisorStrategy = escalator)))
 
   def receive = {

--- a/src/main/scala/ayai/networking/NetworkMessageProcessorSupervisor.scala
+++ b/src/main/scala/ayai/networking/NetworkMessageProcessorSupervisor.scala
@@ -1,0 +1,37 @@
+package ayai.networking
+
+/**
+ * ayai.networking.NetworkMessageProcessorSupervisor
+ * Supervising actor for the NetworkMessageProcessor
+ */
+
+/** Akka Imports **/
+import akka.actor.{Actor, ActorRef, Props, OneForOneStrategy}
+import akka.routing.RoundRobinRouter
+import akka.actor.SupervisorStrategy.Escalate
+
+/** Crane Imports **/
+import crane.{World}
+
+/** External Imports **/
+import scala.concurrent.duration._
+import scala.collection.concurrent.{Map => ConcurrentMap}
+
+class NetworkMessageProcessorSupervisor(world: World, socketMap: ConcurrentMap[String, String]) extends Actor {
+
+  // Escalate exceptions, try up to 10 times, if one actor fails, try just that one again
+  val escalator = OneForOneStrategy(maxNrOfRetries = 10, withinTimeRange = 5 seconds) {
+    case _: Exception => Escalate
+  }
+
+  val router = context.system.actorOf(Props(new NetworkMessageProcessor(context.system, world, socketMap)).withRouter(
+    RoundRobinRouter(5, supervisorStrategy = escalator)))
+
+  def receive = {
+    case message: ProcessMessage =>
+      router forward message 
+    case _ =>
+      println("Error: in interpreter supervisor")
+  }
+
+}


### PR DESCRIPTION
Someone else on backend should look at this and sanity check this.

Basically for each supervisor we can create a variable number of round robin selected actors and forward any messages the supervisor receives to the correct actor.

We can also do interesting things where we allow actors to fail that are taking too long or ran into a bad message, and we simply retry or ignore them.

Did some smoke testing and this seemed to work well, someone else should try it though and see if they can get a concurrency exception of some sort.

I plan to compose futures with whatever processor is returning, but that will be in my next branch.
