### PR TITLE
Revert 6546da2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/*
 /.cache
 *.swp
 *.db
+.idea/

--- a/src/main/scala/ayai/actions/MoveDirection.scala
+++ b/src/main/scala/ayai/actions/MoveDirection.scala
@@ -18,11 +18,11 @@ class MoveDirection(val xDirection: Int, val yDirection: Int) extends Action {
   ** Take the current velocity and multiplies it by the current xDirection and adds that to the position
   **/
   override def process(e: Entity) {
-    (e.getComponent(classOf[Position]),
-      e.getComponent(classOf[Velocity])) match {
-      case(Some(position: Position), Some(velocity: Velocity)) =>
+    (e.getComponent(classOf[Position]), e.getComponent(classOf[Velocity])) match {
+      case (Some(position: Position), Some(velocity: Velocity)) => {
         position.x += xDirection * velocity.x
         position.y += yDirection * velocity.y
+      }
       case _ =>
     }
   }

--- a/src/main/scala/ayai/apps/GameLoop.scala
+++ b/src/main/scala/ayai/apps/GameLoop.scala
@@ -2,59 +2,48 @@ package ayai.apps
 
 /** Ayai Imports **/
 import ayai.networking._
-import ayai.components._
 import ayai.persistence._
 import ayai.gamestate._
 import ayai.factories._
 import ayai.systems.mapgenerator.{WorldGenerator, ExpandRoom}
 
-//Temp for testing!!!
-import ayai.systems.mapgenerator.MapGenerator
-
 /** Akka Imports **/
-import akka.actor.{Actor, ActorRef, ActorSystem, Status, Props}
-import akka.actor.Status.{Success, Failure}
+import akka.actor.{ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 
 /** External Imports **/
-import scala.concurrent.{Await, ExecutionContext, Promise, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.concurrent.{Map => ConcurrentMap, TrieMap}
-import scala.collection.JavaConversions._
-import scala.collection.mutable.{ArrayBuffer, HashMap}
-import java.util.Random
+import scala.collection.mutable.ArrayBuffer
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-
+import java.io.{File, FileWriter, BufferedWriter}
 
 import net.liftweb.json._
 import net.liftweb.json.JsonDSL._
 
-import org.slf4j.{Logger, LoggerFactory}
+import org.slf4j.LoggerFactory
 
 /**
-** The main loop of the Ayai Game
-** First loads all needed Actors, creates needed worlds, and runs the game loop
-**/
+ ** The main loop of the Ayai Game
+ ** First loads all needed Actors, creates needed worlds, and runs the game loop
+ **/
 object GameLoop {
 
-  private val log = LoggerFactory.getLogger(getClass)
+  private lazy val log = LoggerFactory.getLogger(getClass)
 
   var running: Boolean = true
 
   def main(args: Array[String]) {
     implicit val timeout = Timeout(Constants.NETWORK_TIMEOUT seconds)
-    import ExecutionContext.Implicits.global
 
     // COMMENT ME OUT TO SPEED UP BOOTUP TIME
     //This recreates the database and mapList.json file.
     DBCreation.ensureDbExists()
-    var fwMapList = new FileWriter(new File("src/main/resources/assets/maps/mapList.json"))
-    var bwMapList = new BufferedWriter(fwMapList)
+    val fwMapList = new FileWriter(new File("src/main/resources/assets/maps/mapList.json"))
+    val bwMapList = new BufferedWriter(fwMapList)
 
     bwMapList.write(pretty(render(List("map0.json", "map1.json"))))
     bwMapList.close()
@@ -92,7 +81,7 @@ object GameLoop {
     val classFactory = ClassFactory.bootup(networkSystem)
     val effectFactory = EffectFactory.bootup(networkSystem)
 
-    for(file <- rooms){
+    for (file <- rooms) {
       val future = worldFactory ? new CreateWorld(file)
       val result = Await.result(future, timeout.duration).asInstanceOf[RoomWorld]
       roomList ! AddWorld(result)
@@ -113,13 +102,13 @@ object GameLoop {
     receptionist.run(Constants.SERVER_PORT)
 
     //GAME LOOP RUNS AS LONG AS SERVER IS UP
-    while(running) {
+    while (running) {
       val start = System.currentTimeMillis
 
       val processedMessages = new ArrayBuffer[Future[Any]]
       val futureWorlds = roomList ? new GetAllWorlds()
       val worlds = Await.result(futureWorlds, timeout.duration).asInstanceOf[ArrayBuffer[RoomWorld]]
-      for(world <- worlds) {
+      for (world <- worlds) {
         val id = world.id
         val future = mQueue ? FlushMessages(id)
         val result = Await.result(future, timeout.duration).asInstanceOf[QueuedMessages]
@@ -132,16 +121,15 @@ object GameLoop {
 
       Await.result(Future.sequence(processedMessages), 10 seconds)
 
-      for(world <- worlds) {
+      for (world <- worlds) {
         world.process()
       }
 
       val end = System.currentTimeMillis
-      if((end - start) < (1000 / Constants.FRAMES_PER_SECOND)) {
+      if ((end - start) < (1000 / Constants.FRAMES_PER_SECOND)) {
         Thread.sleep((1000 / Constants.FRAMES_PER_SECOND) - (end - start))
       }
     }
   }
 }
-
 

--- a/src/main/scala/ayai/gamestate/GameStateSerializer.scala
+++ b/src/main/scala/ayai/gamestate/GameStateSerializer.scala
@@ -111,7 +111,7 @@ class GameStateSerializer(world: World) extends Actor {
                 JNothing
             }})        
 
-        var projectiles = world.getEntitiesWithExclusions(include=List(classOf[Projectile], classOf[Position], classOf[SpriteSheet]),
+        val projectiles = world.getEntitiesWithExclusions(include=List(classOf[Projectile], classOf[Position], classOf[SpriteSheet]),
                                                   exclude=List(classOf[Dead]))
 
         projectilesJSON = ("projs" -> projectiles.map{ projectile =>
@@ -161,7 +161,6 @@ class GameStateSerializer(world: World) extends Actor {
         case _ => JNothing
       }
     ("models" -> jsonLift)
-
   }
   //Once characters actually have belonging we'll want to implement this and use it in getCharacterRadius
   // def getCharacterBelongings(characterId: String) = {

--- a/src/main/scala/ayai/gamestate/MessageProcessor.scala
+++ b/src/main/scala/ayai/gamestate/MessageProcessor.scala
@@ -80,7 +80,7 @@ class MessageProcessor(world: RoomWorld) extends Actor {
           case None =>
             println(s"Can't find character attached to id: $userId")
           case Some(e: Entity) =>
-              val oldMovement = (e.getComponent(classOf[Actionable])) match {
+              val oldMovement = e.getComponent(classOf[Actionable]) match {
                 case Some(oldMove : Actionable) =>
                   oldMove.active = start
                   if(start)
@@ -274,7 +274,7 @@ class MessageProcessor(world: RoomWorld) extends Actor {
       case DropItemMessage(userId: String, slot: Int) =>
         world.getEntityByTag(s"$userId") match {
           case Some(e: Entity) =>
-            (e.getComponent(classOf[Inventory])) match {
+            e.getComponent(classOf[Inventory]) match {
               case (Some(inventory: Inventory)) =>
                 if(!(inventory.inventory.size <= 0)) {
                   //This should drop by item id not by slot
@@ -291,7 +291,7 @@ class MessageProcessor(world: RoomWorld) extends Actor {
       case AcceptQuestMessage(userId: String, entityId: String, questId: Int) =>
         //might want to calculate interact message here
         // also might want to check distance between npc and player
-        var npcQuest: Quest = world.getEntityByTag(s"$entityId") match {
+        val npcQuest: Quest = world.getEntityByTag(s"$entityId") match {
           case Some(e: Entity) => e.getComponent(classOf[QuestBag]) match {
             case Some(questBag: QuestBag) =>
               var tempQuest: Quest = null

--- a/src/main/scala/ayai/systems/LevelingSystem.scala
+++ b/src/main/scala/ayai/systems/LevelingSystem.scala
@@ -18,33 +18,32 @@ class LevelingSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(in
                                                                                            classOf[Character],
                                                                                            classOf[NetworkingActor])) {
   def processEntity(entity: Entity, deltaTime: Int) {
-    (entity.getComponent(classOf[Experience]),
-      entity.getComponent(classOf[Character]),
-      entity.getComponent(classOf[NetworkingActor])) match {
-      case (Some(experience: Experience), Some(character: Character), Some(na: NetworkingActor)) => 
-        var expThresh = Constants.EXPERIENCE_ARRAY(experience.level-1)
-        var leveledUp = experience.levelUp(expThresh)
-        
-        if(leveledUp) {
+    (entity.getComponent(classOf[Experience]), entity.getComponent(classOf[Character]), entity.getComponent(classOf[NetworkingActor])) match {
+      case (Some(experience: Experience), Some(character: Character), Some(na: NetworkingActor)) => {
+        val expThresh = Constants.EXPERIENCE_ARRAY(experience.level - 1)
+        val leveledUp = experience.levelUp(expThresh)
+
+        if (leveledUp) {
           entity.getComponent(classOf[Stats]) match {
-            case Some(stats: Stats) => 
-              stats.levelUp()
+            case Some(stats: Stats) => stats.levelUp()
             case _ =>
           }
 
           (entity.getComponent(classOf[Health]), entity.getComponent(classOf[Mana])) match {
-            case (Some(health: Health), Some(mana: Mana)) =>
+            case (Some(health: Health), Some(mana: Mana)) => {
               health.levelUp()
               mana.levelUp()
-            case _ => 
+            }
+            case _ =>
           }
-          
+
           val json = ("type" -> "chat") ~
             ("message" -> ("Leveled Up to level " + experience.level.toString)) ~
             ("sender" -> "system")
           val actorSelection = na.actor
           actorSelection ! ConnectionWrite(compact(render(json)))
         }
+      }
       case _ =>
     }
     

--- a/src/main/scala/ayai/systems/NetworkingSystem.scala
+++ b/src/main/scala/ayai/systems/NetworkingSystem.scala
@@ -54,7 +54,7 @@ class NetworkingSystem(networkSystem: ActorSystem) extends TimedSystem(1000/30) 
     val entities = world.getEntitiesByComponents(classOf[Character], classOf[NetworkingActor])
 
     for(characterEntity <- entities) {
-      val characterId: String = (characterEntity.getComponent(classOf[Character])) match {
+      val characterId = characterEntity.getComponent(classOf[Character]) match {
         case Some(c: Character) => c.id
         case _ =>
           log.warn("8192c19: getComponent failed to return anything")
@@ -65,9 +65,8 @@ class NetworkingSystem(networkSystem: ActorSystem) extends TimedSystem(1000/30) 
       val future = serializer ? GetRoomJson(characterEntity)
       val result = Await.result(future, timeout.duration).asInstanceOf[String]
       characterEntity.getComponent(classOf[NetworkingActor]) match {
-            case Some(na : NetworkingActor) =>
-              na.actor ! new ConnectionWrite(result)
-            case _ =>
+        case Some(na : NetworkingActor) => na.actor ! new ConnectionWrite(result)
+        case _ =>
       }
     }
     serializer ! Refresh

--- a/src/main/scala/ayai/systems/RespawningSystem.scala
+++ b/src/main/scala/ayai/systems/RespawningSystem.scala
@@ -16,12 +16,12 @@ object RespawningSystem {
 
 class RespawningSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(include=List(classOf[Room], classOf[Character], classOf[Respawn], classOf[NetworkingActor])) {
   override def processEntity(e: Entity, delta: Int) {
-    var respawn = (e.getComponent(classOf[Respawn]): @unchecked) match {
+    val respawn = (e.getComponent(classOf[Respawn]): @unchecked) match {
       case (Some(r: Respawn)) => r
       case _ => null
     }
     val health = (e.getComponent(classOf[Health]): @unchecked) match {
-      case(Some(h: Health)) => h
+      case (Some(h: Health)) => h
       case _ => null
     }
 

--- a/src/main/scala/ayai/systems/StatusEffectSystem.scala
+++ b/src/main/scala/ayai/systems/StatusEffectSystem.scala
@@ -23,33 +23,30 @@ class StatusEffectSystem() extends EntityProcessingSystem(
 
   def processEntity(e: Entity, deltaTime: Int) {
     e.getComponent(classOf[Health]) match {
-      case Some(health: Health) =>
-        if(health.currentModifiers.size >= 1) {
+      case Some(health: Health) => {
+        if (health.currentModifiers.size >= 1) {
           println("Status Effecting")
           println(health.currentModifiers)
 
         }
-        health.updateCachedValue() 
+        health.updateCachedValue()
+      }
       case _ =>
     }
     e.getComponent(classOf[Mana]) match {
-      case Some(mana: Mana) =>
-        mana.updateCachedValue() 
+      case Some(mana: Mana) => mana.updateCachedValue()
       case _ =>
     }
     e.getComponent(classOf[Experience]) match {
-      case Some(experience: Experience) =>
-        experience.updateCachedValue() 
+      case Some(experience: Experience) => experience.updateCachedValue()
       case _ =>
     }
     e.getComponent(classOf[Stats]) match {
-      case Some(stats: Stats) =>
-        stats.updateCachedValue() 
+      case Some(stats: Stats) => stats.updateCachedValue()
       case _ =>
     }
     e.getComponent(classOf[Velocity]) match {
-      case Some(velocity: Velocity) =>
-        velocity.updateCachedValue() 
+      case Some(velocity: Velocity) => velocity.updateCachedValue()
       case _ =>
     }
   }


### PR DESCRIPTION
Reverts 6546da2 what seem to be breaking changes from the upgrade to a newer version of Crane that I worked on with @timothyhahn. The idea in https://github.com/timothyhahn/crane/commit/f980d8d9369f6db3566ffa1818d0ff331de66f2d was to rid us from having to use `classOf[X]` everywhere and instead just query for the type itself.

The issue I was experiencing that I narrowed down to this commit was components not being transferred correctly when an entity moves between `Room`s in the game. I narrowed bug down to this commit through `git bisect`. If any of you guys want to dig into this, feel free!
